### PR TITLE
resolve paths using require.resolve() and require() instead of ../node_modules

### DIFF
--- a/bin/build_id_editor.js
+++ b/bin/build_id_editor.js
@@ -5,7 +5,7 @@ var cpr = require('cpr')
 var mkdirp = require('mkdirp')
 
 var mpPath = path.resolve(__dirname, '../id_monkey_patches')
-var idPath = path.resolve(__dirname, '../node_modules/iD')
+var idPath = path.dirname(require.resolve('iD/package.json'))
 var idDstPath = path.join(idPath, 'dist')
 var dstPath = path.resolve(__dirname, '../vendor/iD')
 
@@ -28,10 +28,10 @@ cpr(idDstPath, dstPath, {overwrite: true}, done)
 cpr(path.join(idPath, 'data/imagery.json'), dstPath, {overwrite: true}, done)
 
 var presets = {
-  presets: require('../node_modules/iD/data/presets/presets.json'),
-  defaults: require('../node_modules/iD/data/presets/defaults.json'),
-  categories: require('../node_modules/iD/data/presets/categories.json'),
-  fields: require('../node_modules/iD/data/presets/fields.json')
+  presets: require('iD/data/presets/presets.json'),
+  defaults: require('iD/data/presets/defaults.json'),
+  categories: require('iD/data/presets/categories.json'),
+  fields: require('iD/data/presets/fields.json')
 }
 
 fs.writeFileSync(path.join(dstPath, 'presets.json'), JSON.stringify(presets, null, '  '))

--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
     "node": "5.7.0"
   },
   "scripts": {
-    "build": "npm run build:id && npm run build:bundle",
+    "build": "npm run build:id",
     "build:id": "node bin/build_id_editor.js",
-    "build:bundle": "browserify browser/main.js -o public/bundle.js",
-    "build:sync": "browserify browser/sync.js -o public/bundle_sync.js",
     "package-win": "rimraf \"dist/Mapeo CEIBO-win32-x64\" && npm run build:id && electron-packager . \"Mapeo CEIBO\" --out=dist --ignore=\"^/dist\" --platform=win32 --arch=x64 --version=0.36.9 --prune --overwrite --asar",
     "package-mac": "rimraf \"dist/Mapeo CEIBO-darwin-x64\" && npm run build:id && electron-packager . \"Mapeo CEIBO\" --out=dist --ignore=\"^/dist\" --platform=darwin --arch=x64 --version=0.36.9 --prune --overwrite",
     "rebuild-leveldb": "cd node_modules/leveldown && set HOME=~/.electron-gyp && node-gyp rebuild --target=0.36.9 --arch=x64 --dist-url=https://atom.io/download/atom-shell",


### PR DESCRIPTION
npm can install packages into places other than `../node_modules`, so this patch makes these work more reliably under different scenarios