### PR TITLE
remove timeouts for faster editing

### DIFF
--- a/bin/build_id_editor.js
+++ b/bin/build_id_editor.js
@@ -20,6 +20,7 @@ concat([
   path.join(mpPath, 'id-ui-account.js'),
   path.join(mpPath, 'id-svg-tagclasses.js'),
   path.join(mpPath, 'osm-auth.js'),
+  path.join(mpPath, 'no-slow.js'),
   path.join(mpPath, 'end.js')
 ], path.join(dstPath, 'iD-patched.js'), done)
 

--- a/id_monkey_patches/no-slow.js
+++ b/id_monkey_patches/no-slow.js
@@ -1,0 +1,12 @@
+var oldSetTimeout = setTimeout
+window.setTimeout = function (fn, delay) {
+  var src = fn.toString()
+    .replace(/^function\s+\S*\([^\)]*\)\s*{/, '')
+    .replace(/}\s*$/, '')
+    .replace(/\s+/g, '')
+  var slowfn0 = 'loading.close();context.flush();'
+  var slowfn1 = 'callback(null,changeset_id);'
+  if (delay === 2500 && (src === slowfn0 || src === slowfn1)) {
+    return oldSetTimeout(fn, 50)
+  } else return oldSetTimeout.apply(this, arguments)
+}


### PR DESCRIPTION
This hack monkey patches around the setTimeout() that mainline OSM needs because of write throttling, but we don't need anything of the sort. This should speed up editing.