### PR TITLE
hacky way to have the replication UI report properly

### DIFF
--- a/browser/sync.js
+++ b/browser/sync.js
@@ -10,6 +10,8 @@ var ws = wsock('ws://' + osmServerHost)
 pump(ws, split(JSON.parse), through.obj(function (row, enc, next) {
   if (row && row.topic === 'replication-error') {
     resdiv.innerText = row.message
+  } else if (row && row.topic === 'replication-data-complete') {
+    resdiv.innerText = 'data transfer complete, updating indexes...'
   } else if (row && row.topic === 'replication-complete') {
     resdiv.innerText = 'replication complete!'
     setTimeout(function () {

--- a/server.js
+++ b/server.js
@@ -90,7 +90,13 @@ module.exports = function (osm) {
     function onend () {
       if (--pending !== 0) return
       replicating = false
-      send('replication-complete')
+      send('replication-data-complete')
+      setTimeout(function () {
+        osm.ready(function () {
+          console.log('COMPlETE')
+          send('replication-complete')
+        })
+      }, 5000) // HACK, figure out how to not do this in the future
     }
     function syncErr (err) {
       replicating = false


### PR DESCRIPTION
With this hack, the replication UI waits 5 seconds for the hyperlog replication to kick off its add/preadd phase. I haven't figured out how to fix this properly, but this hack seems to work in the meantime.

Make *sure* that dependent modules are using hyperlog-index 4.0.1 or 5.0.1, not 4.0.0 nor 5.0.0! With those upstream fixes, the replication doesn't get permanently hung in the non-ready state.